### PR TITLE
Fix override to WD in auto-publish workflow

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -17,4 +17,4 @@ jobs:
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-web-perf/2021Apr/0005.html
           W3C_BUILD_OVERRIDE: |
-            specStatus: WD
+            Status: WD

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -16,4 +16,5 @@ jobs:
           TOOLCHAIN: bikeshed
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-web-perf/2021Apr/0005.html
-          specStatus: WD
+          W3C_BUILD_OVERRIDE: |
+            specStatus: WD


### PR DESCRIPTION
Syntax introduced in #41 was incorrect, see doc at:
https://w3c.github.io/spec-prod/#w3c_build_override