### PR TITLE
Reorganise the spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -81,7 +81,7 @@ The ABNF (Augmented Backus-Naur Form) syntax for the [:Sec-CH-Device-Memory:] he
 Sec-CH-Device-Memory = sf-decimal
 ```
 
-The [:Sec-CH-Device-Memory:]'s value [=user agent=]'s [=deviceMemory=].
+The [:Sec-CH-Device-Memory:]'s value should be set to the [=user agent=]'s [=deviceMemory=].
 
 ## Client Hint examples ## {#client-hint-examples}
 

--- a/index.bs
+++ b/index.bs
@@ -10,7 +10,7 @@ Editor: Barry Pollard, Google https://google.com, barrypollard@google.com, w3cid
 Editor: Guohui Deng, Microsoft https://microsoft.com, guohuideng@microsoft.com, w3cid 158258
 Former Editor: Shubhie Panicker, Google https://google.com
 Repository: w3c/device-memory
-Abstract: This document defines a HTTP Client Hint header and a JavaScript API to surface device capability for memory i.e. device RAM, in order to enable web apps to customize content depending on device memory constraints.
+Abstract: This document defines a HTTP Client Hint header and a JavaScript API to surface device capability for memory (device RAM) in order to enable web apps to customize content depending on device memory constraints.
 Required IDs: sec-device-memory-client-hint-header
 Default Highlight: js
 </pre>
@@ -27,72 +27,81 @@ urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941; spec: rfc8942
         text: HTTP Client Hint; url: #name-introduction
 </pre>
  
-Introduction {#intro}
-=====================
-Developers need device-class signal for:
-1. Serving light version of the site or specific components, for low-end devices. Examples:
-    * Serve Google "search lite" - a 10KB search results page used in EM.
-    * Serve a light version of video player in Facebook.
-    * Serve lightweight tile images in Google Maps.
+<h2 id="intro">Introduction</h2>
 
-2. Normalizing Metrics: analytics need to be able to normalize their metrics against the device-class. For instance, a 100ms long task on a high end device is a more severe issue compared to a low-end device.
+A device-class signal is used for several reasons, including:
 
-Device memory is an especially useful signal for determining “device-class”. Low memory devices devices (under 512MB, 512MB - 1GB) are widely used in emerging markets.
+- <strong>Serving a light version of the site or specific components</strong>: This is useful to customize a site for low-end devices. Examples include:
+    - Serve “search lite” - a 10KB search results page used for low-end devices.
+    - Serve a light version of video player in a social media web application.
+    - Serve lightweight tile images in a map web application.
 
-Usage Example {#example}
-------------------------
-A server opts in to receive a <code>Sec-CH-Device-Memory</code> [=HTTP Client Hint=] using the <code>Accept-CH</code> header field, or an equivalent HTML meta element with http-equiv attribute:
+- <strong>Normalizing metrics</strong>: analytics need to be able to normalize their metrics against the device-class. For instance, a 100ms long task on a high end device is a more severe issue compared to a low-end device.
 
-<pre class="highlight lang-http">
-    Accept-CH: Sec-CH-Device-Memory
-</pre>
+Device identification and classification based on advertised User-Agent, and other characteristics of the client, are commonly used to select and provide optimized content. Such solutions frequently rely on commercial device databases, which are costly, hard to integrate, and hard to maintain.
 
-In turn, on receiving the above preferences from the server, a compatible user agent would then advertise the device capability for memory, via the <code>Sec-CH-Device-Memory</code> request header field:
+This specification defines a <a href="#sec-device-memory-client-hint-header">(Client Hint) Header Field</a> and a <a href="#device-memory-js-api">JavaScript API</a> which exposes the approximate device memory (RAM) to address these needs without needing to use a device database.
 
-<pre class="highlight lang-http">
-    GET /example HTTP/1.1
-    Sec-CH-Device-Memory: 0.5
-    ...
-</pre>
+<h2 dfn>Computing device memory value</h2>
 
-<code>Sec-CH-Device-Memory</code> (Client Hint) Header Field {#sec-device-memory-client-hint-header}
-=======================================
+<div algorithm>
+    The <dfn>deviceMemory</dfn> getter steps are:
+
+    1.  Let |physicalDeviceMemory| be the amount of physical memory in bytes.
+    2.  Let |minimumLowerBound| be an implementation-specific minimum reported value.
+    3.  Let |maximumUpperBound| be an implementation-specific maximum reported value.
+    4.  Let |deviceMemory| be |physicalDeviceMemory|.
+    5.  Let |power| be 0.
+    6.  [=iteration/While=] |deviceMemory| is greater than 0:
+            1.  Bitwise shift |deviceMemory| right 1 place.
+            2.  Increment |power| by 1.
+    7.  Let |lowerBound| be 1 to the power of |power|.
+    8.  Let |upperBound| be 2 to the power of |power|.
+    9.  If |physicalDeviceMemory| - |lowerBound| <= |physicalDeviceMemory| - |upperBound|, then |deviceMemory|'s value is |lowerBound|.
+    10.  Otherwise |deviceMemory|'s value is |upperBound|.
+    11.  |deviceMemory| is |deviceMemory| / 1024.0.
+    12.  If |deviceMemory| < |minimumLowerBound|, then |deviceMemory| is |minimumLowerBound|.
+    13.  If |deviceMemory| > |maximumUpperBound|, then |deviceMemory| is |maximumUpperBound|.
+    14.  Return |deviceMemory|.
+</div>
+
+Note: The algorithm includes the ability for implementation-specific upper bound and a lower bounds. The range between the upper and the lower bounds should include the majority of device memory values but exclude rare device memory values to mitigate device fingerprinting. Implementations may adjust these bounds over time. These bounds may differ on different device types.
+
+<h2 id="sec-device-memory-client-hint-header"><code>Sec-CH-Device-Memory</code> (Client Hint) Header Field</h2>
 
 The <code>Sec-CH-Device-Memory</code> header field is a [=HTTP Client Hint=] header.
-It is a [=structured header value=] containing an [=item=] which value is a [=decimal=] that indicates the client’s device memory, i.e. the approximate amount of RAM in GiB.
+It is a [=structured header value=] containing an [=item=] which value is a [=decimal=] that indicates the client’s approximate amount of device memory (RAM) in GiB.
+
+If <code>Sec-CH-Device-Memory</code> header field occurs in a message more than once, the last value overrides all previous occurrences.
 
 The ABNF (Augmented Backus-Naur Form) syntax for the <code>Sec-CH-Device-Memory</code> header field is as follows:
 
 ~~~ abnf
-  Sec-CH-Device-Memory = sf-decimal
+Sec-CH-Device-Memory = sf-decimal
 ~~~
 
-<h3 dfn>Computing Device Memory Value</h3>
-The value is calculated by using the actual device memory in MiB then rounding it to the nearest number where only the most significant bit can be set and the rest are zeros (nearest power of two). Then dividing that number by 1024.0 to get the value in GiB.
+The <code>Sec-CH-Device-Memory</code>'s value should be set to [=this=]'s [=deviceMemory=]
 
-An upper bound and a lower bound should be set on the list of values. The range between the upper and the lower bounds should include the majority of device memory values but exclude rare device memory values to mitigate device fingerprinting.
+<h3 id="client-hint-examples">Client Hint examples</h3>
 
-    NOTE: The Implementations may set upper and lower bounds and adjust them dynamically over time. These bounds may even differ on different device types.
+<div class="example">
+    A server opts in to receive a <code>Sec-CH-Device-Memory</code> [=HTTP Client Hint=] using the <code>Accept-CH</code> header field, or an equivalent HTML meta element with http-equiv attribute:
 
-If <code>Sec-CH-Device-Memory</code> header field occurs in a message more than once, the last value overrides all previous occurrences.
+    <pre class="highlight lang-http">
+        Accept-CH: Sec-CH-Device-Memory
+    </pre>
 
+    In turn, on receiving the above preferences from the server, a compatible user agent would then advertise the device capability for memory, via the <code>Sec-CH-Device-Memory</code> request header field:
 
-<h3 dfn>Examples</h3>
+    <pre class="highlight lang-http">
+        GET /example HTTP/1.1
+        Sec-CH-Device-Memory: 8
+        ...
+    </pre>
+</div>
 
-512 MiB will be reported as:
+<h2 id="device-memory-js-api">Device Memory JavaScript API</h2>
 
-<pre class="highlight lang-http">
-    Sec-CH-Device-Memory: 0.5
-</pre>
-
-1000 MiB will be reported as:
-
-<pre class="highlight lang-http">
-    Sec-CH-Device-Memory: 1
-</pre>
-
-Device Memory JS API {#sec-device-memory-js-api}
-=======================================
 <pre class="idl">
 [
     SecureContext,
@@ -105,24 +114,56 @@ Navigator includes NavigatorDeviceMemory;
 WorkerNavigator includes NavigatorDeviceMemory;
 </pre>
 
-    NOTE: <code>self.navigator.deviceMemory</code> Returns the amount of ram in GiB as described in [[#computing-device-memory-value]]
+The <code>deviceMemory</code> getter steps are to return [=this=]'s [=deviceMemory=]
 
-Security Considerations {#sec-security-considerations}
-=======================================
+<h3 id="javascript-examples">JavaScript examples</h3>
 
-<code>Sec-CH-Device-Memory</code> Client Hint header and JS API will only be available to HTTPS secure contexts.  
+<div class="example">
 
-Device identification and classification (e.g. device type and class) based on advertised User-Agent, and other characteristics of the client, are commonly used to select and provide optimized content. Such solutions frequently rely on commercial device databases, which are costly, hard to integrate, and hard to maintain. This specification defines a mechanism to obtain device memory capability that addresses these technical challenges.
+    A web application can either enable or disable features based on device memory.
 
-To reduce fingerprinting risk, reported value is rounded to single most significant bit, as opposed to reporting the exact value. In addition, an upper and lower bound is placed on the reported values.
+    Note: The web application should consider how to handle browsers that do not support the API: either by enabling by default, or disabling by default.
 
-IANA considerations {#iana}
-===================
+    <pre class="highlight lang-javascript">
+        const mem = navigator.deviceMemory;
+
+        // Either disable features if it is known to be a low-memory device
+        if (mem && mem < 2) {
+            // disable features to provide a better experience
+        }
+
+        // Or, alternatively only enable features if the device memory is
+        // either not provided, or known to be above minimum requirements
+        if (!mem || mem > 4) {
+            // enable features to provide a better experience
+        }
+    </pre>
+</div>
+
+<div class="example">
+    A RUM solution can query the device memory using <code>navigator.deviceMemory</code> API and include this in performance beacons as additional information to help explain or segment the data.
+
+    <pre class="highlight lang-javascript">
+        const mem = navigator.deviceMemory;
+        const analyticsData = {
+            memory: mem;
+            ... other metrics
+        }
+        navigator.sendBeacon("/endpoint", analyticsData);
+    </pre>
+</div>
+
+<h2 id="security-and-privacy">Security & privacy considerations</h2>
+
+<code>Sec-CH-Device-Memory</code> Client Hint header and JavaScript API will only be available to HTTPS secure contexts.  
+
+To reduce fingerprinting risk, the reported value is rounded to a single significant bit, as opposed to reporting the exact value. In addition, an implementation-specific upper and lower bound is placed on the reported values. These bounds should be reviewed over time as commonly used device memory characteristics change. Device type should be taken into account when defining these bounds since mobile devices typically have different characteristics than desktops and laptops.
+
+<h2 id="iana">IANA considerations</h2>
 
 This document defines the <code>Sec-CH-Device-Memory</code> HTTP request header field, and registers them in the permanent message header field registry ([[RFC3864]]).
 
-Sec-CH-Device-Memory Header field {#iana-device-memory}
----------------------------------
+<h3 id="iana-device-memory">Sec-CH-Device-Memory Header field</h3>
 
 : Header field name
 :: Sec-CH-Device-Memory
@@ -139,10 +180,6 @@ Sec-CH-Device-Memory Header field {#iana-device-memory}
 : Specification document
 :: this specification ([[#sec-device-memory-client-hint-header]])
 
-<!-- ============================================================ -->
-<h2 id=acknowledgements>Acknowledgements</h2>
-<!-- ============================================================ -->
+<h2 id="acknowledgements">Acknowledgements</h2>
 
-
-Special thanks to <a href="https://github.com/w3c/device-memory/graphs/contributors">all the contributors</a> for their technical input and suggestions that led to improvements to this
-specification.
+Special thanks to the previous editor Shubhie Panicker and <a href="https://github.com/w3c/device-memory/graphs/contributors">all the contributors</a> for their technical input and suggestions that led to improvements to this specification.

--- a/index.bs
+++ b/index.bs
@@ -28,8 +28,7 @@ urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941; spec: rfc8942
         text: HTTP Client Hint; url: #name-introduction
 </pre>
  
-Introduction {#intro}
-============
+# Introduction # {#intro}
 
 A device-class signal is used for several reasons, including:
 
@@ -44,8 +43,7 @@ Device identification and classification based on advertised `User-Agent`, and o
 
 This specification defines a [(Client Hint) Header Field](#sec-device-memory-client-hint-header) and a [JavaScript API](#device-memory-js-api) which exposes the approximate device memory (RAM) to address these needs without needing to use a device database.
 
-Computing device memory value {#computing-device-memory}
-=============================
+# Computing device memory value # {#computing-device-memory}
 
 <div algorithm>
     The <dfn>deviceMemory</dfn> getter steps are:
@@ -70,8 +68,7 @@ Computing device memory value {#computing-device-memory}
 
 Note: The algorithm includes the ability for implementation-specific upper bound and a lower bounds. The range between the upper and the lower bounds should include the majority of device memory values but exclude rare device memory values to mitigate device fingerprinting. Implementations may adjust these bounds over time. These bounds may differ on different device types.
 
-`Sec-CH-Device-Memory` (Client Hint) Header Field {#sec-device-memory-client-hint-header}
-============================================================
+# `Sec-CH-Device-Memory` (Client Hint) Header Field # {#sec-device-memory-client-hint-header}
 
 The `Sec-CH-Device-Memory` header field is a [=HTTP Client Hint=] header.
 It is a [=structured header value=] containing an [=item=] which value is a [=decimal=] that indicates the client’s approximate amount of device memory (RAM) in GiB.
@@ -86,8 +83,7 @@ Sec-CH-Device-Memory = sf-decimal
 
 The `Sec-CH-Device-Memory`'s value should be set to [=this=]'s [=deviceMemory=]
 
-Client Hint examples {#client-hint-examples}
---------------------
+## Client Hint examples ## {#client-hint-examples}
 
 <div class="example">
     A server opts in to receive a `Sec-CH-Device-Memory` [=HTTP Client Hint=] using the `Accept-CH` header field, or an equivalent HTML meta element with http-equiv attribute:
@@ -105,8 +101,7 @@ Client Hint examples {#client-hint-examples}
     ```
 </div>
 
-Device Memory JavaScript API {#device-memory-js-api}
-============================
+# Device Memory JavaScript API # {#device-memory-js-api}
 
 ```idl
 [
@@ -122,8 +117,7 @@ WorkerNavigator includes NavigatorDeviceMemory;
 
 The `deviceMemory` getter steps are to return [=this=]'s [=deviceMemory=]
 
-JavaScript examples {#javascript-examples}
--------------------
+## JavaScript examples ## {#javascript-examples}
 
 <div class="example">
 
@@ -160,20 +154,17 @@ JavaScript examples {#javascript-examples}
     ```
 </div>
 
-Security & privacy considerations {#security-and-privacy}
-=================================
+# Security & privacy considerations # {#security-and-privacy}
 
 `Sec-CH-Device-Memory` Client Hint header and JavaScript API will only be available to HTTPS secure contexts.  
 
 To reduce fingerprinting risk, the reported value is rounded to a single significant bit, as opposed to reporting the exact value. In addition, an implementation-specific upper and lower bound is placed on the reported values. These bounds should be reviewed over time as commonly used device memory characteristics change. Device type should be taken into account when defining these bounds since mobile devices typically have different characteristics than desktops and laptops.
 
-IANA considerations {#iana}
-===================
+# IANA considerations # {#iana}
 
 This document defines the `Sec-CH-Device-Memory` HTTP request header field, and registers them in the permanent message header field registry ([[RFC3864]]).
 
-Sec-CH-Device-Memory Header field {#iana-device-memory}
-=================================
+## `Sec-CH-Device-Memory` header field ## {#iana-device-memory}
 
 : Header field name
 :: Sec-CH-Device-Memory
@@ -188,9 +179,8 @@ Sec-CH-Device-Memory Header field {#iana-device-memory}
 :: IETF
 
 : Specification document
-:: this specification ([[#sec-device-memory-client-hint-header]])
+:: This specification ([[#sec-device-memory-client-hint-header]])
 
-Acknowledgements {#acknowledgements}
-================
+# Acknowledgements # {#acknowledgements}
 
 Special thanks to the previous editor Shubhie Panicker and [all the contributors](https://github.com/w3c/device-memory/graphs/contributors) for their technical input and suggestions that led to improvements to this specification.

--- a/index.bs
+++ b/index.bs
@@ -46,19 +46,19 @@ This specification defines a [(Client Hint) Header Field](#sec-device-memory-cli
 # Computing device memory value # {#computing-device-memory}
 
 <div algorithm>
-    The <dfn>deviceMemory</dfn> getter steps are:
+    The [=user agent=]'s <dfn>deviceMemory</dfn> is calculated by these steps:
 
     1.  Let |physicalDeviceMemory| be the amount of physical memory in bytes.
-    2.  Let |minimumLowerBound| be an implementation-specific minimum reported value.
-    3.  Let |maximumUpperBound| be an implementation-specific maximum reported value.
+    2.  Let |minimumLowerBound| be an [=implementation-defined=] minimum bound.
+    3.  Let |maximumUpperBound| be an [=implementation-defined=] maximum bound.
     4.  Let |deviceMemory| be |physicalDeviceMemory|.
     5.  Let |power| be 0.
     6.  [=iteration/While=] |deviceMemory| is greater than 0:
             1.  Bitwise shift |deviceMemory| right 1 place.
             2.  Increment |power| by 1.
-    7.  Let |lowerBound| be 1 to the power of |power|.
-    8.  Let |upperBound| be 2 to the power of |power|.
-    9.  If |physicalDeviceMemory| - |lowerBound| <= |physicalDeviceMemory| - |upperBound|, then |deviceMemory|'s value is |lowerBound|.
+    7.  Let |lowerBound| be 2 to the power of |power|.
+    8.  Let |upperBound| be 2 to the power of |power + 1|.
+    9.  If |physicalDeviceMemory| − |lowerBound| &le; |upperBound| − |physicalDeviceMemory|, then |deviceMemory|'s value is |lowerBound|.
     10.  Otherwise |deviceMemory|'s value is |upperBound|.
     11.  |deviceMemory| is |deviceMemory| / 1024.0.
     12.  If |deviceMemory| < |minimumLowerBound|, then |deviceMemory| is |minimumLowerBound|.
@@ -66,33 +66,33 @@ This specification defines a [(Client Hint) Header Field](#sec-device-memory-cli
     14.  Return |deviceMemory|.
 </div>
 
-Note: The algorithm includes the ability for implementation-specific upper bound and a lower bounds. The range between the upper and the lower bounds should include the majority of device memory values but exclude rare device memory values to mitigate device fingerprinting. Implementations may adjust these bounds over time. These bounds may differ on different device types.
+The algorithm includes the ability for [=implementation-defined=] upper bound and a lower bounds. The range between the upper and the lower bounds should include the majority of device memory values but exclude rare device memory values to mitigate device fingerprinting. Implementations may adjust these bounds over time. These bounds may differ on different device types.
 
 # `Sec-CH-Device-Memory` (Client Hint) Header Field # {#sec-device-memory-client-hint-header}
 
-The `Sec-CH-Device-Memory` header field is a [=HTTP Client Hint=] header.
+The <dfn http-header>`Sec-CH-Device-Memory`</dfn> header field is a [=HTTP Client Hint=] header.
 It is a [=structured header value=] containing an [=item=] which value is a [=decimal=] that indicates the client’s approximate amount of device memory (RAM) in GiB.
 
-If `Sec-CH-Device-Memory` header field occurs in a message more than once, the last value overrides all previous occurrences.
+If [:Sec-CH-Device-Memory:] header field occurs in a message more than once, the last value overrides all previous occurrences.
 
-The ABNF (Augmented Backus-Naur Form) syntax for the `Sec-CH-Device-Memory` header field is as follows:
+The ABNF (Augmented Backus-Naur Form) syntax for the [:Sec-CH-Device-Memory:] header field is as follows:
 
 ```abnf
 Sec-CH-Device-Memory = sf-decimal
 ```
 
-The `Sec-CH-Device-Memory`'s value should be set to [=this=]'s [=deviceMemory=]
+The [:Sec-CH-Device-Memory:]'s value [=user agent=]'s [=deviceMemory=].
 
 ## Client Hint examples ## {#client-hint-examples}
 
 <div class="example">
-    A server opts in to receive a `Sec-CH-Device-Memory` [=HTTP Client Hint=] using the `Accept-CH` header field, or an equivalent HTML meta element with http-equiv attribute:
+    A server opts in to receive a [:Sec-CH-Device-Memory:] [=HTTP Client Hint=] using the `Accept-CH` header field, or an equivalent HTML meta element with http-equiv attribute:
 
     ```http
         Accept-CH: Sec-CH-Device-Memory
     ```
 
-    In turn, on receiving the above preferences from the server, a compatible user agent would then advertise the device capability for memory, via the `Sec-CH-Device-Memory` request header field:
+    In turn, on receiving the above preferences from the server, a compatible user agent would then advertise the device capability for memory, via the [:Sec-CH-Device-Memory:] request header field:
 
     ```http
         GET /example HTTP/1.1
@@ -115,7 +115,7 @@ Navigator includes NavigatorDeviceMemory;
 WorkerNavigator includes NavigatorDeviceMemory;
 ```
 
-The `deviceMemory` getter steps are to return [=this=]'s [=deviceMemory=]
+The [=NavigatorDeviceMemory=]'s [=NavigatorDeviceMemory/deviceMemory=] getter steps are to return the [=user agent=]'s [=deviceMemory=].
 
 ## JavaScript examples ## {#javascript-examples}
 
@@ -156,13 +156,13 @@ The `deviceMemory` getter steps are to return [=this=]'s [=deviceMemory=]
 
 # Security & privacy considerations # {#security-and-privacy}
 
-`Sec-CH-Device-Memory` Client Hint header and JavaScript API will only be available to HTTPS secure contexts.  
+[:Sec-CH-Device-Memory:] Client Hint header and JavaScript API will only be available to HTTPS secure contexts.  
 
 To reduce fingerprinting risk, the reported value is rounded to a single significant bit, as opposed to reporting the exact value. In addition, an implementation-specific upper and lower bound is placed on the reported values. These bounds should be reviewed over time as commonly used device memory characteristics change. Device type should be taken into account when defining these bounds since mobile devices typically have different characteristics than desktops and laptops.
 
 # IANA considerations # {#iana}
 
-This document defines the `Sec-CH-Device-Memory` HTTP request header field, and registers them in the permanent message header field registry ([[RFC3864]]).
+This document defines the [:Sec-CH-Device-Memory:] HTTP request header field, and registers them in the permanent message header field registry ([[RFC3864]]).
 
 ## `Sec-CH-Device-Memory` header field ## {#iana-device-memory}
 

--- a/index.bs
+++ b/index.bs
@@ -13,6 +13,7 @@ Repository: w3c/device-memory
 Abstract: This document defines a HTTP Client Hint header and a JavaScript API to surface device capability for memory (device RAM) in order to enable web apps to customize content depending on device memory constraints.
 Required IDs: sec-device-memory-client-hint-header
 Default Highlight: js
+Markup Shorthands: markdown yes
 </pre>
 
 <pre class="anchors">
@@ -27,22 +28,24 @@ urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941; spec: rfc8942
         text: HTTP Client Hint; url: #name-introduction
 </pre>
  
-<h2 id="intro">Introduction</h2>
+Introduction {#intro}
+============
 
 A device-class signal is used for several reasons, including:
 
-- <strong>Serving a light version of the site or specific components</strong>: This is useful to customize a site for low-end devices. Examples include:
+- **Serving a light version of the site or specific components**: This is useful to customize a site for low-end devices. Examples include:
     - Serve “search lite” - a 10KB search results page used for low-end devices.
     - Serve a light version of video player in a social media web application.
     - Serve lightweight tile images in a map web application.
 
-- <strong>Normalizing metrics</strong>: analytics need to be able to normalize their metrics against the device-class. For instance, a 100ms long task on a high end device is a more severe issue compared to a low-end device.
+- **Normalizing metrics**: analytics need to be able to normalize their metrics against the device-class. For instance, a 100ms long task on a high end device is a more severe issue compared to a low-end device.
 
-Device identification and classification based on advertised User-Agent, and other characteristics of the client, are commonly used to select and provide optimized content. Such solutions frequently rely on commercial device databases, which are costly, hard to integrate, and hard to maintain.
+Device identification and classification based on advertised `User-Agent`, and other characteristics of the client, are commonly used to select and provide optimized content. Such solutions frequently rely on commercial device databases, which are costly, hard to integrate, and hard to maintain.
 
-This specification defines a <a href="#sec-device-memory-client-hint-header">(Client Hint) Header Field</a> and a <a href="#device-memory-js-api">JavaScript API</a> which exposes the approximate device memory (RAM) to address these needs without needing to use a device database.
+This specification defines a [(Client Hint) Header Field](#sec-device-memory-client-hint-header) and a [JavaScript API](#device-memory-js-api) which exposes the approximate device memory (RAM) to address these needs without needing to use a device database.
 
-<h2 dfn>Computing device memory value</h2>
+Computing device memory value {#computing-device-memory}
+=============================
 
 <div algorithm>
     The <dfn>deviceMemory</dfn> getter steps are:
@@ -67,42 +70,45 @@ This specification defines a <a href="#sec-device-memory-client-hint-header">(Cl
 
 Note: The algorithm includes the ability for implementation-specific upper bound and a lower bounds. The range between the upper and the lower bounds should include the majority of device memory values but exclude rare device memory values to mitigate device fingerprinting. Implementations may adjust these bounds over time. These bounds may differ on different device types.
 
-<h2 id="sec-device-memory-client-hint-header"><code>Sec-CH-Device-Memory</code> (Client Hint) Header Field</h2>
+`Sec-CH-Device-Memory` (Client Hint) Header Field {#sec-device-memory-client-hint-header}
+============================================================
 
-The <code>Sec-CH-Device-Memory</code> header field is a [=HTTP Client Hint=] header.
+The `Sec-CH-Device-Memory` header field is a [=HTTP Client Hint=] header.
 It is a [=structured header value=] containing an [=item=] which value is a [=decimal=] that indicates the client’s approximate amount of device memory (RAM) in GiB.
 
-If <code>Sec-CH-Device-Memory</code> header field occurs in a message more than once, the last value overrides all previous occurrences.
+If `Sec-CH-Device-Memory` header field occurs in a message more than once, the last value overrides all previous occurrences.
 
-The ABNF (Augmented Backus-Naur Form) syntax for the <code>Sec-CH-Device-Memory</code> header field is as follows:
+The ABNF (Augmented Backus-Naur Form) syntax for the `Sec-CH-Device-Memory` header field is as follows:
 
-~~~ abnf
+```abnf
 Sec-CH-Device-Memory = sf-decimal
-~~~
+```
 
-The <code>Sec-CH-Device-Memory</code>'s value should be set to [=this=]'s [=deviceMemory=]
+The `Sec-CH-Device-Memory`'s value should be set to [=this=]'s [=deviceMemory=]
 
-<h3 id="client-hint-examples">Client Hint examples</h3>
+Client Hint examples {#client-hint-examples}
+--------------------
 
 <div class="example">
-    A server opts in to receive a <code>Sec-CH-Device-Memory</code> [=HTTP Client Hint=] using the <code>Accept-CH</code> header field, or an equivalent HTML meta element with http-equiv attribute:
+    A server opts in to receive a `Sec-CH-Device-Memory` [=HTTP Client Hint=] using the `Accept-CH` header field, or an equivalent HTML meta element with http-equiv attribute:
 
-    <pre class="highlight lang-http">
+    ```http
         Accept-CH: Sec-CH-Device-Memory
-    </pre>
+    ```
 
-    In turn, on receiving the above preferences from the server, a compatible user agent would then advertise the device capability for memory, via the <code>Sec-CH-Device-Memory</code> request header field:
+    In turn, on receiving the above preferences from the server, a compatible user agent would then advertise the device capability for memory, via the `Sec-CH-Device-Memory` request header field:
 
-    <pre class="highlight lang-http">
+    ```http
         GET /example HTTP/1.1
         Sec-CH-Device-Memory: 8
         ...
-    </pre>
+    ```
 </div>
 
-<h2 id="device-memory-js-api">Device Memory JavaScript API</h2>
+Device Memory JavaScript API {#device-memory-js-api}
+============================
 
-<pre class="idl">
+```idl
 [
     SecureContext,
     Exposed=(Window,Worker)
@@ -112,11 +118,12 @@ The <code>Sec-CH-Device-Memory</code>'s value should be set to [=this=]'s [=devi
 
 Navigator includes NavigatorDeviceMemory;
 WorkerNavigator includes NavigatorDeviceMemory;
-</pre>
+```
 
-The <code>deviceMemory</code> getter steps are to return [=this=]'s [=deviceMemory=]
+The `deviceMemory` getter steps are to return [=this=]'s [=deviceMemory=]
 
-<h3 id="javascript-examples">JavaScript examples</h3>
+JavaScript examples {#javascript-examples}
+-------------------
 
 <div class="example">
 
@@ -124,7 +131,7 @@ The <code>deviceMemory</code> getter steps are to return [=this=]'s [=deviceMemo
 
     Note: The web application should consider how to handle browsers that do not support the API: either by enabling by default, or disabling by default.
 
-    <pre class="highlight lang-javascript">
+    ```javascript
         const mem = navigator.deviceMemory;
 
         // Either disable features if it is known to be a low-memory device
@@ -137,33 +144,36 @@ The <code>deviceMemory</code> getter steps are to return [=this=]'s [=deviceMemo
         if (!mem || mem > 4) {
             // enable features to provide a better experience
         }
-    </pre>
+    ```
 </div>
 
 <div class="example">
-    A RUM solution can query the device memory using <code>navigator.deviceMemory</code> API and include this in performance beacons as additional information to help explain or segment the data.
+    A RUM solution can query the device memory using `navigator.deviceMemory` API and include this in performance beacons as additional information to help explain or segment the data.
 
-    <pre class="highlight lang-javascript">
+    ```javascript
         const mem = navigator.deviceMemory;
         const analyticsData = {
             memory: mem;
             ... other metrics
         }
         navigator.sendBeacon("/endpoint", analyticsData);
-    </pre>
+    ```
 </div>
 
-<h2 id="security-and-privacy">Security & privacy considerations</h2>
+Security & privacy considerations {#security-and-privacy}
+=================================
 
-<code>Sec-CH-Device-Memory</code> Client Hint header and JavaScript API will only be available to HTTPS secure contexts.  
+`Sec-CH-Device-Memory` Client Hint header and JavaScript API will only be available to HTTPS secure contexts.  
 
 To reduce fingerprinting risk, the reported value is rounded to a single significant bit, as opposed to reporting the exact value. In addition, an implementation-specific upper and lower bound is placed on the reported values. These bounds should be reviewed over time as commonly used device memory characteristics change. Device type should be taken into account when defining these bounds since mobile devices typically have different characteristics than desktops and laptops.
 
-<h2 id="iana">IANA considerations</h2>
+IANA considerations {#iana}
+===================
 
-This document defines the <code>Sec-CH-Device-Memory</code> HTTP request header field, and registers them in the permanent message header field registry ([[RFC3864]]).
+This document defines the `Sec-CH-Device-Memory` HTTP request header field, and registers them in the permanent message header field registry ([[RFC3864]]).
 
-<h3 id="iana-device-memory">Sec-CH-Device-Memory Header field</h3>
+Sec-CH-Device-Memory Header field {#iana-device-memory}
+=================================
 
 : Header field name
 :: Sec-CH-Device-Memory
@@ -180,6 +190,7 @@ This document defines the <code>Sec-CH-Device-Memory</code> HTTP request header 
 : Specification document
 :: this specification ([[#sec-device-memory-client-hint-header]])
 
-<h2 id="acknowledgements">Acknowledgements</h2>
+Acknowledgements {#acknowledgements}
+================
 
-Special thanks to the previous editor Shubhie Panicker and <a href="https://github.com/w3c/device-memory/graphs/contributors">all the contributors</a> for their technical input and suggestions that led to improvements to this specification.
+Special thanks to the previous editor Shubhie Panicker and [all the contributors](https://github.com/w3c/device-memory/graphs/contributors) for their technical input and suggestions that led to improvements to this specification.

--- a/index.bs
+++ b/index.bs
@@ -51,19 +51,18 @@ This specification defines a [(Client Hint) Header Field](#sec-device-memory-cli
     1.  Let |physicalDeviceMemory| be the amount of physical memory in bytes.
     2.  Let |minimumLowerBound| be an [=implementation-defined=] minimum bound.
     3.  Let |maximumUpperBound| be an [=implementation-defined=] maximum bound.
-    4.  Let |deviceMemory| be |physicalDeviceMemory|.
+    4.  Let |deviceMemory| be |physicalDeviceMemory| / 1024.0.
     5.  Let |power| be 0.
-    6.  [=iteration/While=] |deviceMemory| is greater than 0:
+    6.  [=iteration/While=] |deviceMemory| is greater than 1:
             1.  Bitwise shift |deviceMemory| right 1 place.
             2.  Increment |power| by 1.
     7.  Let |lowerBound| be 2 to the power of |power|.
     8.  Let |upperBound| be 2 to the power of |power + 1|.
     9.  If |physicalDeviceMemory| − |lowerBound| &le; |upperBound| − |physicalDeviceMemory|, then |deviceMemory|'s value is |lowerBound|.
     10.  Otherwise |deviceMemory|'s value is |upperBound|.
-    11.  |deviceMemory| is |deviceMemory| / 1024.0.
-    12.  If |deviceMemory| < |minimumLowerBound|, then |deviceMemory| is |minimumLowerBound|.
-    13.  If |deviceMemory| > |maximumUpperBound|, then |deviceMemory| is |maximumUpperBound|.
-    14.  Return |deviceMemory|.
+    11.  If |deviceMemory| < |minimumLowerBound|, then |deviceMemory| is |minimumLowerBound|.
+    12.  If |deviceMemory| > |maximumUpperBound|, then |deviceMemory| is |maximumUpperBound|.
+    13.  Return |deviceMemory|.
 </div>
 
 The algorithm includes the ability for [=implementation-defined=] upper bound and a lower bounds. The range between the upper and the lower bounds should include the majority of device memory values but exclude rare device memory values to mitigate device fingerprinting. Implementations may adjust these bounds over time. These bounds may differ on different device types.
@@ -81,7 +80,7 @@ The ABNF (Augmented Backus-Naur Form) syntax for the [:Sec-CH-Device-Memory:] he
 Sec-CH-Device-Memory = sf-decimal
 ```
 
-The [:Sec-CH-Device-Memory:]'s value [=user agent=]'s [=deviceMemory=].
+The [:Sec-CH-Device-Memory:]'s value should be set to the [=user agent=]'s [=deviceMemory=].
 
 ## Client Hint examples ## {#client-hint-examples}
 


### PR DESCRIPTION
This PR cleans up the spec but doesn't make any actual changes (Correct me if I'm wrong).

- Adds an algorithm for calcing the device memory (replacing kinda vague spec). Based on [Chromium's implementation](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/common/device_memory/approximated_device_memory.cc;l=33) (which is the only implementation at this writing).
- There were some places where this spec's origin as a Client Hint header was apparent (e.g. the device memory calc was under client hints, even though it's just as relevant to the JS API)
- Removes specific references to companies (Google and Facebook) from intro
- Switch to markdown where possible rather than the hybrid markdown/HTML/bikeshed it was before.
- Cleans up headers to sentence case
- Misc editorial improvements

@domfarolino if you could review with your spec-pertise that would be greatly appreciated!