### PR TITLE
Fix WebIDL definitions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -102,7 +102,7 @@ The [:Sec-CH-Device-Memory:]'s value should be set to the [=user agent=]'s [=dev
 
 # Device Memory JavaScript API # {#device-memory-js-api}
 
-```idl
+<pre class="idl">
 [
     SecureContext,
     Exposed=(Window,Worker)
@@ -112,9 +112,9 @@ The [:Sec-CH-Device-Memory:]'s value should be set to the [=user agent=]'s [=dev
 
 Navigator includes NavigatorDeviceMemory;
 WorkerNavigator includes NavigatorDeviceMemory;
-```
+</pre>
 
-The [=NavigatorDeviceMemory=]'s [=NavigatorDeviceMemory/deviceMemory=] getter steps are to return the [=user agent=]'s [=deviceMemory=].
+The {{NavigatorDeviceMemory}}'s {{NavigatorDeviceMemory/deviceMemory}} getter steps are to return the [=user agent=]'s [=deviceMemory=].
 
 ## JavaScript examples ## {#javascript-examples}
 


### PR DESCRIPTION
PR #57 replaced the `<pre class="idl">` block with a Markdown code block but Bikeshed needs WebIDL blocks to be wrapped in `<pre class="idl">` to enable automatic dfns and linking of the terms it contains, see:
  https://speced.github.io/bikeshed/#idl

Also, references to IDL terms need to use the `{{foo}}` shorthand, see:
  https://speced.github.io/bikeshed/#autolink-wrappers
